### PR TITLE
Pcp LMS Updates

### DIFF
--- a/evo/evo_oled/extension/usr/local/etc/evo_oled/config.js
+++ b/evo/evo_oled/extension/usr/local/etc/evo_oled/config.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const readline = require('node:readline/promises');
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+}); 
+
+var TIME_BEFORE_SCREENSAVER = 120; // in sec  
+var TIME_BEFORE_DEEPSLEEP = 480; // in sec
+var CONTRAST = 254; // range 1-254
+var DATE_FORMAT = "DD/MM/YYYY"
+var TIME_FORMAT = "HH:mm:ss"
+
+const path = process.argv[2] || fs.readFileSync(__dirname+'/lms/default_path').toString();
+
+try{
+  var data = JSON.parse(fs.readFileSync(path+'/config.json').toString())
+
+  TIME_BEFORE_SCREENSAVER = (data && data.sleep_after) ? data.sleep_after : TIME_BEFORE_SCREENSAVER;
+  TIME_BEFORE_DEEPSLEEP = (data && data.deep_sleep_after) ? data.deep_sleep_after : TIME_BEFORE_DEEPSLEEP;
+  CONTRAST = (data && data.contrast) ? data.contrast : CONTRAST;
+  DATE_FORMAT = (data && data.date_format) ? data.date_format : DATE_FORMAT;
+  TIME_FORMAT = (data && data.time_format) ? data.time_format : TIME_FORMAT;
+}
+catch(e){}
+
+(async ()=>{
+
+  const sleep_after = await rl.question(`\nTime before screensaver in seconds? (default : ${TIME_BEFORE_SCREENSAVER} )\n`) || TIME_BEFORE_SCREENSAVER;
+  const deep_sleep_after = await rl.question(`Time before screen blanking? (default : ${TIME_BEFORE_DEEPSLEEP} )\n`) || TIME_BEFORE_DEEPSLEEP;
+  const contrast = await rl.question(`Contrast? (default : ${CONTRAST})\n`) || CONTRAST;
+  const date_format = await rl.question(`Date Format? (default : ${DATE_FORMAT})\n`) || DATE_FORMAT;
+  const time_format = await rl.question(`Time Format? (default : ${TIME_FORMAT})\n`) || TIME_FORMAT;
+  
+  
+  rl.close();
+
+  fs.writeFileSync(path+'/config.json', 
+    JSON.stringify({sleep_after:parseInt(sleep_after), deep_sleep_after:parseInt(deep_sleep_after), contrast:parseInt(contrast), date_format, time_format})
+  );
+})();

--- a/evo/evo_oled/extension/usr/local/etc/evo_oled/index.js
+++ b/evo/evo_oled/extension/usr/local/etc/evo_oled/index.js
@@ -161,7 +161,7 @@ ap_oled.prototype.listen_to = async function(api,frequency){
       
       
       streamer.on("trackChange", d=>{
-        this.text_to_display = streamer.formatedMainString;
+        this.text_to_display = streamer.formattedMainString;
         this.driver.CacheGlyphsData( this.text_to_display);
 				this.text_width = this.driver.getStringWidthUnifont(this.text_to_display + " - ");
         this.scroller_x = 0;
@@ -186,45 +186,16 @@ ap_oled.prototype.listen_to = async function(api,frequency){
 		}
       })
       streamer.on("seekChange", d=>{
-        this.data.seek_string = streamer.formatedSeek.seek_string;
-        this.data.ratiobar  = streamer.formatedSeek.ratiobar ;
+        this.data.seek_string = streamer.formattedSeek.seek_string;
+        this.data.ratiobar  = streamer.formattedSeek.ratiobar ;
         this.handle_sleep(true);	
       })
 
-	        
-	  const formatSamplerate = (data)=>{
-		switch (data){
-			case "176.4k":
-				data = "DSD64"
-				break;
-			case "352.8k":
-				data = "DSD128"
-				break;
-			case "705.6k":
-				data = "DSD256"
-				break;
-			default:
-				data = (parseFloat(data)/1000).toString() + "k"
-			}
-		return data
-	  }
-      	        
-	  const formatSamplesize = (data)=>{
-		switch (data){
-			case "16":
-			case "24":
-			case "32":
-				data = data + "Bit"
-				break;
-			}	
-		return data
-	  }
-      
       const foot = ()=>{
         this.footertext = "";
 				if ( streamer.playerData.bitrate ) this.footertext += streamer.playerData.bitrate + " "
-				if ( streamer.playerData.samplerate ) this.footertext +=formatSamplerate(streamer.playerData.samplerate) + " "
-				if ( streamer.playerData.samplesize ) this.footertext +=formatSamplesize(streamer.playerData.samplesize) + " "
+				if ( streamer.formattedSamplerate ) this.footertext +=streamer.formattedSamplerate + " "
+				if ( streamer.formattedSamplesize ) this.footertext +=streamer.formattedSamplesize + " "
 			}
 
       streamer.on("bitRateChange",    ()=>foot()  );

--- a/evo/evo_oled/extension/usr/local/etc/evo_oled/lms/lms.js
+++ b/evo/evo_oled/extension/usr/local/etc/evo_oled/lms/lms.js
@@ -312,7 +312,7 @@ function _Player(player_info, connection){
 	
 	this.isLocal = this._checkIsLocal();
 	this.id = this.serverData.playerid;
-	this.name = this.serverData.name;
+	this.name = this.serverData.name;	
 	this.playerData = {};
   
   this.state = "stop";
@@ -329,7 +329,7 @@ function _Player(player_info, connection){
 _Player.prototype.subscribe = function(refreshRate){
 	
 	refreshRate = refreshRate || 1;
-	const query = `${this.id} status - 1 tags:aCJjKTolrx subscribe:${refreshRate}`;
+	const query = `${this.id} status - 1 tags:aCJjKTolrxI subscribe:${refreshRate}`;
 	
 	return this.connection.query(query)
 	.then(response=>{
@@ -425,6 +425,10 @@ _Player.prototype.processChanges = function(key, data){
 	else if(key === "samplerate"){
 		this.emit( "sampleRateChange", data );
 		this.emit( "line0", "Sample Rate : " + data );
+	}
+	else if(key === "samplesize"){
+		this.emit( "sampleSizeChange", data );
+		this.emit( "line0", "Sample Size : " + data );
 	}
 	else if(key === "type"){
 		this.emit( "encodingChange", data );

--- a/evo/evo_oled/extension/usr/local/etc/evo_oled/lms/lms.js
+++ b/evo/evo_oled/extension/usr/local/etc/evo_oled/lms/lms.js
@@ -395,7 +395,9 @@ function _Player(player_info, connection){
 	this.playerData = {};
   
   this.state = "stop";
-  this.formatedMainString = "";
+  this.formattedMainString = "";
+  this.formattedSamplesize = "";
+  this.formattedSamplerate = "";
   this.watchingIdle = false;
 	this.idle = false;
 	this._idleTimeout = null;
@@ -477,7 +479,7 @@ _Player.prototype.updateStatus = function(newStatus){
 _Player.prototype.processChanges = function(key, data){
   if( ["current_title", "title", "artist", "album"].includes(key) ){
     this.formatMainString();
-    this.emit( "trackChange", this.formatedMainString );
+    this.emit( "trackChange", this.formattedMainString );
     if(this.state === "play") this.resetIdleTimeout(); // sinon les webradios sortent l'écran de veille 
   }
 	else if(key === "mode"){
@@ -491,7 +493,7 @@ _Player.prototype.processChanges = function(key, data){
 	}
 	else if( ["can_seek", "time", "duration"].includes(key)){
 		this.seekFormat();
-		this.emit( "seekChange", this.formatedSeek );
+		this.emit( "seekChange", this.formattedSeek );
 	}
 	else if(key === "mixer volume"){
 		this.resetIdleTimeout();
@@ -502,12 +504,14 @@ _Player.prototype.processChanges = function(key, data){
 		this.emit( "line2", "Bit Rate : " + data );
 	}
 	else if(key === "samplerate"){
-		this.emit( "sampleRateChange", data );
-		this.emit( "line0", "Sample Rate : " + data );
+		this.formatSamplerate();
+		this.emit( "sampleRateChange", this.formattedSamplerate );
+		this.emit( "line0", "Sample Rate : " + this.formattedSamplerate );
 	}
 	else if(key === "samplesize"){
-		this.emit( "sampleSizeChange", data );
-		this.emit( "line0", "Sample Size : " + data );
+		this.formatSamplesize();
+		this.emit( "sampleSizeChange", this.formattedSamplesize );
+		this.emit( "line0", "Sample Size : " + this.formattedSamplesize );
 	}
 	else if(key === "type"){
 		this.emit( "encodingChange", data );
@@ -565,8 +569,40 @@ _Player.prototype._checkIsLocal = function(){
 }
 
 _Player.prototype.formatMainString = function (){
-  this.formatedMainString = this.playerData.title + (this.playerData.artist?" - " + this.playerData.artist:"") + (this.playerData.album?" - " + this.playerData.album:"");
+  this.formattedMainString = this.playerData.title + (this.playerData.artist?" - " + this.playerData.artist:"") + (this.playerData.album?" - " + this.playerData.album:"");
 }
+
+_Player.prototype.formatSamplesize = function (){
+
+	switch (this.playerData.samplesize){
+		case "16":
+		case "24":
+		case "32":
+			this.formattedSamplesize = this.playerData.samplesize + "Bit"
+			break;
+		default:
+			this.formattedSamplesize = this.playerData.samplesize
+		}	
+}
+
+_Player.prototype.formatSamplerate = function (){
+
+	switch (this.playerData.samplerate){
+		case "176.4k":
+			this.formattedSamplerate = "DSD64"
+			break;
+		case "352.8k":
+			this.formattedSamplerate = "DSD128"
+			break;
+		case "705.6k":
+			this.formattedSamplerate = "DSD256"
+			break;
+		default:
+			this.formattedSamplerate = (parseFloat(this.playerData.samplerate)/1000).toString() + "k"
+		}
+}
+
+
 
 _Player.prototype.seekFormat = function (){
 	
@@ -596,9 +632,9 @@ _Player.prototype.seekFormat = function (){
 	} 
 	seek_string = seek +" / "+ duration;
 	
-	this.formatedSeek = {seek_string:seek_string,ratiobar:ratiobar};
+	this.formattedSeek = {seek_string:seek_string,ratiobar:ratiobar};
 	
-	return( this.formatedSeek );
+	return( this.formattedSeek );
 }
 
 

--- a/evo/evo_oled/extension/usr/local/etc/evo_oled/lms/lms.js
+++ b/evo/evo_oled/extension/usr/local/etc/evo_oled/lms/lms.js
@@ -318,9 +318,9 @@ function _Player(player_info, connection){
   this.state = "stop";
   this.formatedMainString = "";
   this.watchingIdle = false;
-	this.iddle = false;
-	this._iddleTimeout = null;
-	this.iddletime = 900;
+	this.idle = false;
+	this._idleTimeout = null;
+	this.idletime = 900;
 	
 	//this._subscription = null;
 }
@@ -406,6 +406,10 @@ _Player.prototype.processChanges = function(key, data){
 		this.resetIdleTimeout();
 		this.emit( "stateChange", data );
 	}
+	else if(key === "power"){
+		this.resetIdleTimeout();
+		this.emit( "powerChange", data );
+	}
 	else if( ["can_seek", "time", "duration"].includes(key)){
 		this.seekFormat();
 		this.emit( "seekChange", this.formatedSeek );
@@ -438,29 +442,29 @@ _Player.prototype.processChanges = function(key, data){
 }
 
 // should use inheritance here 
-_Player.prototype.watchIdleState = function(iddletime){
+_Player.prototype.watchIdleState = function(idletime){
 	this.watchingIdle = true;
-	this.iddletime = iddletime;
-	clearTimeout(this._iddleTimeout);
-	this._iddleTimeout = setTimeout( ()=>{
+	this.idletime = idletime;
+	clearTimeout(this._idleTimeout);
+	this._idleTimeout = setTimeout( ()=>{
 		if(! this.watchingIdle ) return;
-		this.iddle = true;
-		this.emit("iddleStart")
-	}, this.iddletime );
+		this.idle = true;
+		this.emit("idleStart")
+	}, this.idletime );
 }
 // should use inheritance here 
 _Player.prototype.resetIdleTimeout = function(){
 	if(! this.watchingIdle ) return;
-	if( this.iddle  ) this.emit("iddleStop");
-	this.iddle = false;
-	this._iddleTimeout.refresh();
+	if( this.idle  ) this.emit("idleStop");
+	this.idle = false;
+	this._idleTimeout.refresh();
 }
 // should use inheritance here 
 _Player.prototype.clearIdleTimeout = function(){
 	this.watchingIdle = false;
-	if( this.iddle  ) this.emit("iddleStop");
-	this.iddle = false;
-	clearTimeout(this._iddleTimeout);
+	if( this.idle  ) this.emit("idleStop");
+	this.idle = false;
+	clearTimeout(this._idleTimeout);
 }
 
 _Player.prototype._checkIsLocal = function(){
@@ -554,10 +558,4 @@ async function getlocalStreamer( path ){
 }
 
 module.exports = getlocalStreamer;
-
-
-
-
-
-
 

--- a/evo/evo_oled/extension/usr/local/etc/evo_oled/lms/lms.js
+++ b/evo/evo_oled/extension/usr/local/etc/evo_oled/lms/lms.js
@@ -389,6 +389,8 @@ function _Player(player_info, connection){
 	this.serverData = this.parseStatusResponse(player_info); // not parsing nor validating anything beyond this point is kinda risky
 	this.connection = connection;
 	
+	this.lmsIp = connection.address
+	
 	this.isLocal = this._checkIsLocal();
 	this.id = this.serverData.playerid;
 	this.name = this.serverData.name;

--- a/evo/evo_oled/extension/usr/local/etc/evo_oled/lms/login.js
+++ b/evo/evo_oled/extension/usr/local/etc/evo_oled/lms/login.js
@@ -6,19 +6,45 @@ const rl = readline.createInterface({
   output: process.stdout,
 }); 
 
+var currentPort = 9090
+var currentHost = '127.0.0.1'
+var currentLogin = ''
+var currentPassword = ''
 
 const path = process.argv[2] || fs.readFileSync(__dirname+'/default_path').toString();
 
+try{
+  var data = JSON.parse(fs.readFileSync(path+'/lms/config.json').toString())
+
+  currentPort = (data && data.port) ? data.port : currentPort;
+  currentHost = (data && data.host) ? data.host : currentHost;
+  currentLogin = (data && data.login) ? data.login : currentLogin;
+
+  if(data.pass){
+    const k = fs.readFileSync(path+'/lms/k/k');
+    let iv = Buffer.from(data.pass.iv, 'hex');
+    let encryptedText = Buffer.from(data.pass.encryptedData, 'hex');
+    const decipher = crypto.createDecipheriv('aes-256-cbc', Buffer.from(k), iv);
+    let decrypted = decipher.update(encryptedText);
+    decrypted = Buffer.concat([decrypted, decipher.final()]);
+    data.pass = decrypted.toString();
+  }
+
+  currentPassword = (data && data.pass) ? data.pass : currentPassword;
+
+}
+catch(e){}
 
 (async ()=>{
-  const port = (await rl.question('Which port is your LMS telnet using ? (default :  9090)\n')) || 9090;
-  const host = await rl.question('Which host is your LMS telnet using ? (default : 127.0.0.1)\n') || '127.0.0.1';
-  const login = await rl.question('Login for your LMS ? (leave blank if you have no login/password set)\n');
-  const pass = await rl.question('Password for your LMS ? (leave blank if you have no login/password set)\n');
+
+  const port = await rl.question(`\nWhich port is your LMS telnet using ? (default : ${currentPort} )\n`) || currentPort;
+  const host = await rl.question(`Which host is your LMS telnet using ? (default : ${currentHost} )\n`) || currentHost;
+  const login = await rl.question(`Login for your LMS ? (default : ${currentLogin}) (Leave blank if you have no login/password set)\n` || currentLogin);
+  const pass = await rl.question(`Password for your LMS ? (default : ${currentPassword}) (Leave blank if you have no login/password set)\n` || currentPassword);
   rl.close();
   let securepass;
   
-   fs.mkdirSync(path+"/lms/k", { recursive: true } )
+  fs.mkdirSync(path+"/lms/k", { recursive: true } )
   
   if(pass){
     const k = generateKey();
@@ -29,8 +55,6 @@ const path = process.argv[2] || fs.readFileSync(__dirname+'/default_path').toStr
     JSON.stringify({port, host, login, pass:securepass})
   );
 })();
-
-
 
 function generateKey() {
     return crypto.randomBytes(32); // AES-256 key


### PR DESCRIPTION

I've made a number of updates to make this more specific for LMS environments.  Changes are as follows

Read the LMS IP address from PCP.CFG as default.  If the LMS server is non-discoverable, the address will be specified here by default.

If no LMS IP in PCP, attempt to discover the LMS IP through broadcasting on UDP - same way as squeezelite discovers.  If both these methods fail, then use the lms/config.json or default to local.  The local default will likely not be used since discovery will find the local server anyway.

I found the current behaviour of 3 layers of screensaver very confusing.  I added detection of the power state of the squeezelite player and used the clock as the screen display when the player is off, then used the snake and blank screen savers as before.

The reading of the values from the config failed - it was taking item.value as if it was reading from a web page, not just item.

Changed the spelling of iddle to idle (since the rest of the var names are in english)

Read and use existing values of login.json if it exists

Add a script to create config.js through readline questions

Add date and time formats to config.json

I also created a small .js to automatically change contrast on sunrise/sunset and use the http server to update the contrast - happy to share if you like the idea.


If the contrast is changed whilst the screen is off, it's not updated.  So, reset the contrast on screen wake

Format the values for samplerate for DSD values

Add samplesize metdata and format correctly